### PR TITLE
 FE : implemented front-end only pagination to allProducts view

### DIFF
--- a/client/components/AllProducts.js
+++ b/client/components/AllProducts.js
@@ -3,6 +3,7 @@ import { connect } from 'react-redux';
 import { fetchProducts } from '../store/products';
 import { createCartItem } from '../store/cart';
 import { Link } from 'react-router-dom';
+import Pagination from './Pagination';
 
 const AllProducts = (props) => {
   useEffect(() => {
@@ -14,6 +15,9 @@ const AllProducts = (props) => {
   const [strs, setStr] = useState(true);
   const [keys, setKeys] = useState(true);
   const [access, setAccess] = useState(true);
+
+  const [currentPage, setCurrentPage] = useState(1);
+  const [productsPerPage] = useState(8);
 
   const filteredArr = (products, category) => {
     return products.filter((product) => product.category !== category);
@@ -41,6 +45,13 @@ const AllProducts = (props) => {
   if (strs === false) filteredProd = filteredArr(filteredProd, 'string');
   if (keys === false) filteredProd = filteredArr(filteredProd, 'keys');
   if (access === false) filteredProd = filteredArr(filteredProd, 'accessories');
+
+  //pagination:
+  const indexOfLastProduct = currentPage * productsPerPage;
+  const indexOfFirstProduct = indexOfLastProduct - productsPerPage;
+  const currentProducts = filteredProd.slice(indexOfFirstProduct, indexOfLastProduct);
+  //page-changer:
+  const paginate = (pageNum) => setCurrentPage(pageNum);
 
   return (
     <div className='all-products-container'>
@@ -80,7 +91,7 @@ const AllProducts = (props) => {
           onChange={updateAccessory}
         />
       </div>
-      {filteredProd.map((product) => {
+      {currentProducts.map((product) => {
         return (
           <div key={product.id} className='product-container'>
             <Link to={`/products/${product.id}`}>
@@ -113,6 +124,11 @@ const AllProducts = (props) => {
           </div>
         );
       })}
+      <Pagination 
+      productsPerPage={productsPerPage} 
+      totalProducts={filteredProd.length} 
+      paginate={paginate}
+      />
     </div>
   );
 };

--- a/client/components/Pagination.js
+++ b/client/components/Pagination.js
@@ -1,0 +1,24 @@
+import React from 'react';
+
+const Pagination = ( {productsPerPage, totalProducts, paginate } ) => {
+    const pageNumbers = [];
+    for( let i=1; i<Math.ceil(totalProducts / productsPerPage); i++)   {
+        pageNumbers.push(i);
+    }
+
+    return (
+        <nav>
+            <ul className="pagination" >
+                {pageNumbers.map((num) => (
+                    <li key={num} className="page-item" >
+                        <a onClick={() => paginate(num) } href="#" className="page-link" >{num}</a>
+                    </li>
+                )
+                )}
+            </ul>
+        </nav>
+    )
+
+}
+
+export default Pagination;

--- a/public/style.css
+++ b/public/style.css
@@ -19,3 +19,13 @@ form div {
   margin: 1em;
   display: inline-block;
 }
+
+.pagination {
+  display: flex;
+  flex-direction: row;
+}
+
+.page-item {
+  list-style-type: none;
+  border: solid, black, 1px;
+}

--- a/script/seed.js
+++ b/script/seed.js
@@ -63,7 +63,7 @@ const stringImages = [
   'https://www.amazon.com/Daisy-Rock-Special-Velvet-Electric/dp/B001SASQ2A',
   'https://pixabay.com/en/electric-guitar-rock-guitar-1669233/',
   'https://www.walmart.com/ip/Gold-Classic-Rock-N-Roll-6-Stringed-Acoustic-Guitar-Toy-Guitar-Musical-Instrument-for-Kids-Includes-Guitar-Pick-Extra-Guitar-String/426828935',
-  'http://www.engadget.com/2008/09/11/rock-band-2-standalone-instruments-set-to-ship-next-week/',
+  'https://www.richtonemusic.co.uk/product/--classic-rock-l-electric-guitar/',
   'https://www.amazon.com/Daisy-Rock-WildWood-Artist-Acoustic-Electric/dp/B001SASQ0C',
   'https://www.wired.com/wp-content/uploads/images_blogs/gamelife/2010/10/mustang.png',
   'https://i.pinimg.com/originals/74/74/67/747467b691390ba54a1e4c666bd857ed.jpg',


### PR DESCRIPTION
Pagination component available in AllProducts view, logic works with filters. I also removed and replaced any img links from seed that were not rendering, and put in very basic styling for pagination nav bar in style.css so they do not render as bullets.

Requesting Kavin to check out since the AllProducts component was your baby.